### PR TITLE
Add luuk1983.json to the samples folder

### DIFF
--- a/samples/luuk1983.json
+++ b/samples/luuk1983.json
@@ -2,6 +2,7 @@
     {
         "title": "Add custom condition to an existing backoffice extension",
         "description": "This sample demonstrates how to add a custom condition to an existing backoffice extension in Umbraco.",
-        "url": "https://github.com/Luuk1983/UmbracoExamples/blob/main/ConditionsToExistingExtensions/README.md"
+        "url": "https://github.com/Luuk1983/UmbracoExamples/blob/main/ConditionsToExistingExtensions",
+        "readme": "https://github.com/Luuk1983/UmbracoExamples/blob/main/ConditionsToExistingExtensions/README.md"
     }
 ]

--- a/samples/luuk1983.json
+++ b/samples/luuk1983.json
@@ -1,0 +1,7 @@
+[
+    {
+        "title": "Add custom condition to an existing backoffice extension",
+        "description": "This sample demonstrates how to add a custom condition to an existing backoffice extension in Umbraco.",
+        "url": "https://github.com/Luuk1983/UmbracoExamples/blob/main/ConditionsToExistingExtensions/README.md"
+    }
+]


### PR DESCRIPTION
I like to add myself to the list of participants. I have a repository where I will add multiple Umbraco code examples to. So when I have more examples, I can't just link to the entire repo as a whole, but rather to a subsection or folder. To me it made sense to link the url to the readme file directly (instead of using the readme property for that). But I'm not sure how this will be used and parsed in the future, so let me know if I should change anything!