### PR TITLE
Add blog for syncing NuGet and Umbraco package versions

### DIFF
--- a/samples/luuk1983.json
+++ b/samples/luuk1983.json
@@ -4,5 +4,10 @@
         "description": "This sample demonstrates how to add a custom condition to an existing backoffice extension in Umbraco.",
         "url": "https://github.com/Luuk1983/UmbracoExamples/blob/main/ConditionsToExistingExtensions",
         "readme": "https://github.com/Luuk1983/UmbracoExamples/blob/main/ConditionsToExistingExtensions/README.md"
+    },
+        {
+        "title": "How to Sync NuGet and Umbraco Package versions automatically in Umbraco 14+",
+        "description": "Automatically sync your umbraco-package.json version with your NuGet package version in Umbraco 14+.",
+        "url": "https://dev.to/luukpeters/how-to-sync-nuget-and-umbraco-package-versions-automatically-in-umbraco-14-8i3"
     }
 ]


### PR DESCRIPTION
This adds my blog that describes how to sync the version of the Umbraco extension in umbraco-package.json with the version of the NuGet package.

From what I could tell, blogs with code samples area also a good source for examples on the new community site, so that's why I added it. Otherwise, let me know!